### PR TITLE
Contador para las resistencis del BCD

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,20 +3,22 @@
 #fuses NOPBADEN, NOMCLR, STVREN, NOLVP, NODEBUG
 #use delay(clock=16000000)
 
-#define __DEBUG_SERIAL__ //Si comentas esta linea se deshabilita el debug por serial y el PIN_C6 puede ser usado en forma digital I/O
-
-#ifdef __DEBUG_SERIAL__
-   #define TX_232        PIN_C6
-   #use RS232(BAUD=9600, XMIT=TX_232, BITS=8,PARITY=N, STOP=1)
-   #use fast_io(c)
-#endif
+#use fast_io(a)
+#use fast_io(b)
+#use fast_io(c)
+#use fast_io(d)
+#use fast_io(e)
 
 void main (void){
    setup_oscillator(OSC_16MHZ);
-#ifdef __DEBUG_SERIAL__ //Deberiamos de proteger nuestras depuraciones de esta forma o usar una macro ya protegida.
-   printf("Hola Mundo\n");//Puedes usar putc o printf. Revisa la documentación de CCS para ver que mas puedes hacer.
-#endif
+   set_tris_c(0x00);
+   int contador=0x80;//o la otra frecuencia, idk;
+
    while(1){
-      
+      output_c(contador);
+      delay_ms(24);//o los que vayan a ser
+      contador=contador>>1;
+      if(contador==0)
+         contador=0x80;
    }
 }	


### PR DESCRIPTION
Se configura un contador de anillo para controlar el paso de las resistencias para el BCD
